### PR TITLE
Ignore most stuff in debian dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ vendor/*
 !spc.spec
 !Makefile
 .pc
-!debian/**
-debian/spc.bash-completion
+!debian/rules
+!debian/control
+!debian/copyright
+!debian/changelog
+!debian/source/format


### PR DESCRIPTION
There are a lot of files generated there at build that we don't need