### PR TITLE
Fix: spc search track now uses QueueSongOpt for recs

### DIFF
--- a/cmd/search.go
+++ b/cmd/search.go
@@ -78,7 +78,6 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 		var opts spotify.PlayOptions
 		opts.DeviceID = &conf.DeviceID
 
-		var recommendedIDs []spotify.ID
 
 		switch searchType {
 		case "track":
@@ -90,8 +89,10 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 			if err != nil {
 				glog.Fatal(err)
 			}
-			for _, track := range recommends.Tracks {
-				recommendedIDs = append(recommendedIDs, track.ID)
+			for _, val := range recommends.Tracks {
+				if err := conf.Client.QueueSongOpt(val.ID, &opts); err != nil {
+					glog.Fatal(err)
+				}
 			}
 			opts.URIs = append(opts.URIs, toPlay)
 		case "album", "playlist", "artist":
@@ -104,11 +105,6 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 		}
 		if err := conf.Client.PlayOpt(&opts); err != nil {
 			glog.Fatal(err)
-		}
-		for _, val := range recommendedIDs {
-			if err := conf.Client.QueueSongOpt(val, &opts); err != nil {
-				glog.Fatal(err)
-			}
 		}
 	},
 	ValidArgs: []string{"track", "album", "playlist", "artist"},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -77,6 +77,9 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 		toPlay := fuzzySearchResults(*searchResults, searchType)
 		var opts spotify.PlayOptions
 		opts.DeviceID = &conf.DeviceID
+
+		var recommendedIDs []spotify.ID
+
 		switch searchType {
 		case "track":
 			//This lines up some songs to play after the search result plays
@@ -87,12 +90,10 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 			if err != nil {
 				glog.Fatal(err)
 			}
-			var recommendURIs []spotify.URI
 			for _, track := range recommends.Tracks {
-				recommendURIs = append(recommendURIs, track.URI)
+				recommendedIDs = append(recommendedIDs, track.ID)
 			}
 			opts.URIs = append(opts.URIs, toPlay)
-			opts.URIs = append(opts.URIs, recommendURIs...)
 		case "album", "playlist", "artist":
 			opts.PlaybackContext = &toPlay
 		}
@@ -103,6 +104,11 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 		}
 		if err := conf.Client.PlayOpt(&opts); err != nil {
 			glog.Fatal(err)
+		}
+		for _, val := range recommendedIDs {
+			if err := conf.Client.QueueSongOpt(val, &opts); err != nil {
+				glog.Fatal(err)
+			}
 		}
 	},
 	ValidArgs: []string{"track", "album", "playlist", "artist"},


### PR DESCRIPTION
Fixes #102 

As i said in https://github.com/dvdmuckle/spc/issues/102#issuecomment-943676137. I don't have Spotify Premium but this was a small fix and the maintainer was straightforward in the possible fix so it made this PR possible.