### PR TITLE
Update go.mod to use go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.16
+        go-version: ^1.17
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dvdmuckle/spc
 
-go 1.16
+go 1.17
 
 require (
 	github.com/golang/glog v1.0.0
@@ -11,5 +11,6 @@ require (
 	github.com/zalando/go-keyring v0.2.1
 	github.com/zmb3/spotify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
+
+require gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect


### PR DESCRIPTION
Some dependencies have updated and look to require/prefer compiling with Go 1.17