### PR TITLE
Add missing depends, notably gnome-keyring

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,9 @@ Package: spc
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         dbus-x11
+         dbus-x11,
+         bash-completion,
+         gnome-keyring
 Built-Using: ${misc:Built-Using}
 Description: A lightweight multiplatform CLI for Spotify
  spc Go

--- a/spc.spec
+++ b/spc.spec
@@ -38,6 +38,7 @@ BuildRequires:  git
 
 Requires: bash-completion
 Requires: dbus-x11
+Requires: gnome-keyring
 
 %description
 %{common_description}


### PR DESCRIPTION
Doesn't close #164 , but does address it somewhat for the time being.