### PR TITLE
Bump github.com/zmb3/spotify from 1.3.0 to 2.4.0

### DIFF
--- a/cmd/helper/authHelp.go
+++ b/cmd/helper/authHelp.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ limitations under the License.
 package helper
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -28,22 +29,34 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
+	"github.com/zmb3/spotify/v2/auth"
 	"golang.org/x/oauth2"
 )
 
 const redirectURI = "http://localhost:8888/callback"
 
 var (
-	authenticator = spotify.NewAuthenticator(redirectURI, spotify.ScopeStreaming, spotify.ScopeUserModifyPlaybackState, spotify.ScopeUserReadPlaybackState, spotify.ScopePlaylistModifyPrivate, spotify.ScopePlaylistModifyPublic)
-	ch            = make(chan *spotify.Client)
-	clientID      string
-	secret        string
-	state         = "ringdingthing"
+	authenticator = spotifyauth.New(
+		spotifyauth.WithRedirectURL(redirectURI),
+		spotifyauth.WithClientID(clientID),
+		spotifyauth.WithClientSecret(secret),
+		spotifyauth.WithScopes(
+			spotifyauth.ScopeStreaming,
+			spotifyauth.ScopeUserModifyPlaybackState,
+			spotifyauth.ScopeUserReadPlaybackState,
+			spotifyauth.ScopePlaylistModifyPrivate,
+			spotifyauth.ScopePlaylistModifyPublic,
+		),
+	)
+	ch       = make(chan *spotify.Client)
+	clientID string
+	secret   string
+	state    = "ringdingthing"
 )
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {
-	tok, err := authenticator.Token(state, r)
+	tok, err := authenticator.Token(r.Context(), state, r)
 	if err != nil {
 		http.Error(w, "Couldn't get token", http.StatusForbidden)
 		LogErrorAndExit(err)
@@ -53,12 +66,12 @@ func completeAuth(w http.ResponseWriter, r *http.Request) {
 		LogErrorAndExit(fmt.Sprintf("State mismatch: %s != %s\n", st, state))
 	}
 	// use the token to get an authenticated client
-	client := authenticator.NewClient(tok)
+	client := spotify.New(authenticator.Client(r.Context(), tok))
 	fmt.Fprintf(w, "Login Completed!")
-	ch <- &client
+	ch <- client
 }
 
-//Auth authenticates with Spotify and refreshes the token
+// Auth authenticates with Spotify and refreshes the token
 func Auth(cmd *cobra.Command, cfgFile string, conf *Config) {
 	clientID = conf.ClientID
 	secret = conf.Secret
@@ -91,15 +104,18 @@ func Auth(cmd *cobra.Command, cfgFile string, conf *Config) {
 		}
 	} else {
 		fmt.Println("Getting token...")
-		authenticator.SetAuthInfo(clientID, secret)
 		http.HandleFunc("/callback", completeAuth)
 		go http.ListenAndServe(":8888", nil)
 		url := authenticator.AuthURL(state)
 		fmt.Println("Please log in to Spotify by clicking the following link, or copying it to a web browser:", url)
 		//wait for auth to finish
 		client := <-ch
+		if client == nil {
+			fmt.Println("Client is not initialized")
+			return
+		}
 
-		user, err := client.CurrentUser()
+		user, err := client.CurrentUser(context.Background())
 		if err != nil {
 			LogErrorAndExit(err)
 		}
@@ -119,13 +135,13 @@ func Auth(cmd *cobra.Command, cfgFile string, conf *Config) {
 	}
 }
 
-//RefreshToken refreshes the auth token from Spotify
+// RefreshToken refreshes the auth token from Spotify
 func RefreshToken(client string, secret string, refreshToken string) *oauth2.Token {
 	var token *oauth2.Token = &oauth2.Token{}
 
 	if refreshToken != "" {
 		const grantType string = "refresh_token"
-		const tokenURL string = spotify.TokenURL
+		const tokenURL string = spotifyauth.TokenURL
 		const contentType string = "application/x-www-form-urlencoded"
 		form := url.Values{}
 		form.Add("grant_type", grantType)
@@ -153,8 +169,8 @@ func RefreshToken(client string, secret string, refreshToken string) *oauth2.Tok
 	return nil
 }
 
-//SetClient sets the Client field of Config struct to a valid Spotify client
-//The Token field in the Config struct must be set
+// SetClient sets the Client field of Config struct to a valid Spotify client
+// The Token field in the Config struct must be set
 func SetClient(conf *Config) {
 	curUser, err := user.Current()
 	if err != nil {
@@ -187,5 +203,10 @@ func SetClient(conf *Config) {
 			LogErrorAndExit("Error saving token to keyring", err)
 		}
 	}
-	conf.Client = spotify.NewAuthenticator(redirectURI).NewClient(&conf.Token)
+	httpClient := authenticator.Client(context.Background(), &conf.Token)
+	conf.Client = spotify.New(httpClient)
+	if conf.Client == nil {
+		fmt.Println("Client is not initialized")
+		return
+	}
 }

--- a/cmd/helper/playback.go
+++ b/cmd/helper/playback.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,23 +16,25 @@ limitations under the License.
 package helper
 
 import (
-	"github.com/zmb3/spotify"
+	"context"
+
+	"github.com/zmb3/spotify/v2"
 )
 
-//Pause wraps the spotify.Client.Pause() method for easy error checking
+// Pause wraps the spotify.Client.Pause() method for easy error checking
 func Pause(conf *Config) {
 	var opts spotify.PlayOptions
 	opts.DeviceID = &conf.DeviceID
-	if err := conf.Client.PauseOpt(&opts); err != nil {
+	if err := conf.Client.PauseOpt(context.Background(), &opts); err != nil {
 		LogErrorAndExit(err)
 	}
 }
 
-//Play wraps the spotify.Client.Play() method for easy error checking
+// Play wraps the spotify.Client.Play() method for easy error checking
 func Play(conf *Config) {
 	var opts spotify.PlayOptions
 	opts.DeviceID = &conf.DeviceID
-	if err := conf.Client.PlayOpt(&opts); err != nil {
+	if err := conf.Client.PlayOpt(context.Background(), &opts); err != nil {
 		LogErrorAndExit(err)
 	}
 }

--- a/cmd/helper/structs.go
+++ b/cmd/helper/structs.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 package helper
 
 import (
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 	"golang.org/x/oauth2"
 )
 
-//Config stores constantly accessed variables in memory
+// Config stores constantly accessed variables in memory
 type Config struct {
 	ClientID string
 	Secret   string
 	Token    oauth2.Token
-	Client   spotify.Client
+	Client   *spotify.Client
 	DeviceID spotify.ID
 }

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+
 	"github.com/dvdmuckle/spc/cmd/helper"
 	"github.com/spf13/cobra"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 // nextCmd represents the next command
@@ -28,7 +30,7 @@ var nextCmd = &cobra.Command{
 	Long:  `Skips the track currently playing. Will use the currently configured device.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		helper.SetClient(&conf)
-		conf.Client.NextOpt(&spotify.PlayOptions{DeviceID: &conf.DeviceID})
+		conf.Client.NextOpt(context.Background(), &spotify.PlayOptions{DeviceID: &conf.DeviceID})
 	},
 	Aliases: []string{"skip"},
 }

--- a/cmd/previous.go
+++ b/cmd/previous.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
+
 	"github.com/dvdmuckle/spc/cmd/helper"
 	"github.com/spf13/cobra"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 // previousCmd represents the previous command
@@ -30,13 +32,16 @@ var previousCmd = &cobra.Command{
 		var opts spotify.PlayOptions
 		helper.SetClient(&conf)
 		opts.DeviceID = &conf.DeviceID
+
+		ctx := context.Background()
+
 		//We want to go to the last song playing, but
 		//spotify.Previous() will rewind the current song
 		//unless the current song is close to the beginning
 		//of playback, so we seek to zero here before calling
 		//spotify.Previous()
-		conf.Client.SeekOpt(0, &opts)
-		conf.Client.PreviousOpt(&opts)
+		conf.Client.SeekOpt(ctx, 0, &opts)
+		conf.Client.PreviousOpt(ctx, &opts)
 	},
 	Aliases: []string{"prev"},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/dvdmuckle/spc/cmd/helper"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 
 	"github.com/spf13/cobra"
 

--- a/cmd/saveWeekly.go
+++ b/cmd/saveWeekly.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/dvdmuckle/spc/cmd/helper"
@@ -92,7 +93,7 @@ func getPlaylistDate() string {
 func deduplicatePlaylist(playlistName string, user string) bool {
 	if conf.Client == nil {
 		fmt.Println("Client is not initialized")
-		return false
+		os.Exit(1)
 	}
 	searchResults, err := conf.Client.Search(context.Background(), playlistName, spotify.SearchTypePlaylist)
 	if err != nil {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -24,7 +25,7 @@ import (
 	"github.com/dvdmuckle/spc/cmd/helper"
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 // searchCmd represents the search command
@@ -60,15 +61,17 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 		searchTerm := strings.Join(args[1:], " ")
 		var searchResults *spotify.SearchResult
 		var err error
+		ctx := context.Background()
+
 		switch searchType {
 		case "track":
-			searchResults, err = conf.Client.Search(searchTerm, spotify.SearchTypeTrack)
+			searchResults, err = conf.Client.Search(ctx, searchTerm, spotify.SearchTypeTrack)
 		case "album":
-			searchResults, err = conf.Client.Search(searchTerm, spotify.SearchTypeAlbum)
+			searchResults, err = conf.Client.Search(ctx, searchTerm, spotify.SearchTypeAlbum)
 		case "playlist":
-			searchResults, err = conf.Client.Search(searchTerm, spotify.SearchTypePlaylist)
+			searchResults, err = conf.Client.Search(ctx, searchTerm, spotify.SearchTypePlaylist)
 		case "artist":
-			searchResults, err = conf.Client.Search(searchTerm, spotify.SearchTypeArtist)
+			searchResults, err = conf.Client.Search(ctx, searchTerm, spotify.SearchTypeArtist)
 		}
 		if err != nil {
 			helper.LogErrorAndExit(err)
@@ -82,7 +85,7 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 			regexID := regexp.MustCompile(`(spotify:track:)(.*)`)
 			trackID := spotify.ID(regexID.FindStringSubmatch(string(toPlay))[2])
 			seeds := spotify.Seeds{Tracks: []spotify.ID{trackID}}
-			recommends, err := conf.Client.GetRecommendations(seeds, nil, nil)
+			recommends, err := conf.Client.GetRecommendations(ctx, seeds, nil, nil)
 			if err != nil {
 				helper.LogErrorAndExit(err)
 			}
@@ -97,10 +100,10 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 		}
 		//If a user tries to play a track with shuffle on,
 		//they'll instead get the related tracks first
-		if err := conf.Client.ShuffleOpt(false, &opts); err != nil {
+		if err := conf.Client.ShuffleOpt(ctx, false, &opts); err != nil {
 			helper.LogErrorAndExit(err)
 		}
-		if err := conf.Client.PlayOpt(&opts); err != nil {
+		if err := conf.Client.PlayOpt(ctx, &opts); err != nil {
 			helper.LogErrorAndExit(err)
 		}
 	},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -85,7 +85,7 @@ please see https://pkg.go.dev/github.com/zmb3/spotify?tab=doc#Client.Search`,
 			regexID := regexp.MustCompile(`(spotify:track:)(.*)`)
 			trackID := spotify.ID(regexID.FindStringSubmatch(string(toPlay))[2])
 			seeds := spotify.Seeds{Tracks: []spotify.ID{trackID}}
-			recommends, err := conf.Client.GetRecommendations(ctx, seeds, nil, nil)
+			recommends, err := conf.Client.GetRecommendations(ctx, seeds, nil)
 			if err != nil {
 				helper.LogErrorAndExit(err)
 			}

--- a/cmd/seek.go
+++ b/cmd/seek.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -23,7 +24,7 @@ import (
 
 	"github.com/dvdmuckle/spc/cmd/helper"
 	"github.com/spf13/cobra"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 var seekCmd = &cobra.Command{
@@ -56,7 +57,8 @@ the form of minutes:seconds.`,
 			}
 		}
 
-		currentlyPlaying, err := conf.Client.PlayerCurrentlyPlaying()
+		ctx := context.Background()
+		currentlyPlaying, err := conf.Client.PlayerCurrentlyPlaying(ctx)
 		if err != nil {
 			helper.LogErrorAndExit(err)
 		}
@@ -74,7 +76,7 @@ the form of minutes:seconds.`,
 			os.Exit(1)
 		}
 
-		err = conf.Client.SeekOpt(position*1000, &spotify.PlayOptions{DeviceID: &conf.DeviceID})
+		err = conf.Client.SeekOpt(ctx, position*1000, &spotify.PlayOptions{DeviceID: &conf.DeviceID})
 		if err != nil {
 			helper.LogErrorAndExit(err)
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -23,7 +24,7 @@ import (
 
 	"github.com/dvdmuckle/spc/cmd/helper"
 	"github.com/spf13/cobra"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 type Status spotify.CurrentlyPlaying
@@ -52,7 +53,7 @@ the command will return an empty string. This may happen if Spotify is paused
 for an extended period of time`,
 	Run: func(cmd *cobra.Command, args []string) {
 		helper.SetClient(&conf)
-		status, err := conf.Client.PlayerCurrentlyPlaying()
+		status, err := conf.Client.PlayerCurrentlyPlaying(context.Background())
 		if err != nil {
 			helper.LogErrorAndExit(err)
 		}
@@ -79,7 +80,7 @@ func init() {
 	statusCmd.Flags().StringP("format", "f", "", "Format string for formatting the status")
 }
 
-//Format implements Formatter for Spotify status
+// Format implements Formatter for Spotify status
 func (stat Status) Format(state fmt.State, verb rune) {
 	switch verb {
 	case 'f':

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -23,7 +24,7 @@ import (
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 var switchCmd = &cobra.Command{
@@ -85,7 +86,7 @@ func init() {
 }
 
 func transferPlayback(conf *helper.Config, shouldPlay bool) {
-	if err := conf.Client.TransferPlayback(conf.DeviceID, shouldPlay); err != nil {
+	if err := conf.Client.TransferPlayback(context.Background(), conf.DeviceID, shouldPlay); err != nil {
 		helper.LogErrorAndExit(err)
 	}
 }
@@ -96,7 +97,7 @@ func clearDeviceEntry(conf *helper.Config) {
 }
 
 func getDeviceList(conf *helper.Config) []spotify.PlayerDevice {
-	devices, err := conf.Client.PlayerDevices()
+	devices, err := conf.Client.PlayerDevices(context.Background())
 	if err != nil {
 		helper.LogErrorAndExit(err)
 	}

--- a/cmd/volume.go
+++ b/cmd/volume.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,14 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/dvdmuckle/spc/cmd/helper"
 	"github.com/spf13/cobra"
-	"github.com/zmb3/spotify"
+	"github.com/zmb3/spotify/v2"
 )
 
 // volumeCmd represents the volume command
@@ -49,7 +50,7 @@ one argument, a number between 0 and 100 to set the volume to.`,
 			fmt.Println("Volume cannot be less than 0")
 			os.Exit(1)
 		}
-		conf.Client.VolumeOpt(int(vol), &spotify.PlayOptions{DeviceID: &conf.DeviceID})
+		conf.Client.VolumeOpt(context.Background(), int(vol), &spotify.PlayOptions{DeviceID: &conf.DeviceID})
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.17.0
 	github.com/zalando/go-keyring v0.2.3
-	github.com/zmb3/spotify v1.3.0
+	github.com/zmb3/spotify/v2 v2.4.0
 	golang.org/x/oauth2 v0.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,7 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -225,8 +226,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97yms=
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
-github.com/zmb3/spotify v1.3.0 h1:6Z2F1IMx0Hviq/dpf8nFwvKPppFEMXn8yfReSBVi16k=
-github.com/zmb3/spotify v1.3.0/go.mod h1:GD7AAEMUJVYc2Z7p2a2S0E3/5f/KxM/vOnErNr4j+Tw=
+github.com/zmb3/spotify/v2 v2.4.0 h1:ZHdhBx/Qyn7rtVDP+onk/oSvtL5uVyJtb+VBLrNDC7Y=
+github.com/zmb3/spotify/v2 v2.4.0/go.mod h1:m6c3mHgZSt1rTF76UfSfdn1Gb2Kx/B/ClCcr+2V1Scw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -314,6 +315,7 @@ golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -325,6 +327,7 @@ golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210810183815-faf39c7919d5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.13.0 h1:jDDenyj+WgFtmV3zYVoi8aE2BwtXFLWOA67ZfNWftiY=
 golang.org/x/oauth2 v0.13.0/go.mod h1:/JMhi4ZRXAf4HG9LiNmxvk+45+96RUlVThiH8FzNBn0=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -378,12 +381,14 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -395,6 +400,7 @@ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -543,6 +549,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

This PR resolves #97, which updates the `github.com/zmb3/spotify` package from version `1.3.0` to `2.4.0`.

## Changes Made

- Updated the version in `go.mod` and ran `go get` to fetch the new version.
- Made necessary code adjustments in `/cmd` to accommodate breaking changes introduced between 1.3.0 and 2.4.0 versions.
