### PR TITLE
Don't wait for fedora builds to finish

### DIFF
--- a/.github/workflows/fedora-release.yml
+++ b/.github/workflows/fedora-release.yml
@@ -29,4 +29,4 @@ jobs:
           dnf -y install copr-cli
 
       - name: Submit the build by uploading the spec
-        run: copr build dvdmuckle/spc spc.spec
+        run: copr build --nowait dvdmuckle/spc spc.spec


### PR DESCRIPTION
Saves us some hours on GHA by not waiting for COPR builds to finish when submitting them
